### PR TITLE
Update highlightjs to 8.0.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "angular": "PatternConsulting/bower-angular#~1.1.5",
-    "highlightjs": "~7.3.0",
+    "highlightjs": "8.0.0",
     "ngSelect": "~0.1.0",
     "bootstrap": "~3.0.0-rc1",
     "angular-ui-router": "~0.0.1"


### PR DESCRIPTION
Installation with Bower failed during checking dependencies. Bumping to 8.0.0 fixes this problem.
