### PR TITLE
fix(included json): don't let angular parse json

### DIFF
--- a/angular-highlightjs.js
+++ b/angular-highlightjs.js
@@ -175,7 +175,14 @@ function ($http,   $templateCache,   $q) {
             templateCachePromise = $templateCache.get(src);
             if (!templateCachePromise) {
               dfd = $q.defer();
-              $http.get(src, {cache: $templateCache}).success(function (code) {
+              $http.get(src, {
+                cache: $templateCache,
+                transformResponse: function(data, headersGetter) {
+                  // Return the raw string, so $http doesn't parse it
+                  // if it's json.
+                  return data;
+                }
+              }).success(function (code) {
                 if (thisChangeId !== changeCounter) {
                   return;
                 }


### PR DESCRIPTION
When doing an $http request, json gets parsed by angular. This is avoided by
returning the raw data as a string in the transformResponse function.

This made it impossible to include a static json file.
