### PR TITLE
fix(\n): Fix first occurrence of \n line ending

### DIFF
--- a/angular-highlightjs.js
+++ b/angular-highlightjs.js
@@ -113,7 +113,7 @@ function HljsCtrl (hljsCache,   hljsService) {
     compile: function(tElm, tAttrs, transclude) {
       // get static code
       // strip the starting "new line" character
-      var staticCode = tElm[0].innerHTML.replace(/^\r\n|\r|\n/, '');
+      var staticCode = tElm[0].innerHTML.replace(/^(\r\n|\r|\n)/m, '');
 
       // put template
       tElm.html('<pre><code class="hljs"></code></pre>');
@@ -230,7 +230,7 @@ function ($http,   $templateCache,   $q) {
                 code = code.data;
               }
 
-              code = code.replace(/^\r\n|\r|\n/, '');
+              code = code.replace(/^(\r\n|\r|\n)/m, '');
               ctrl.highlight(code);
             });
           }


### PR DESCRIPTION
Previously the first occurrence of a '\n' or '\r' character would be removed if
the file did not start with \r\n.

Fixes [Issue #9](https://github.com/pc035860/angular-highlightjs/issues/9). This turned out to be a bug after all. I was onable to reproduce it on plunkr, because the loaded template contains \r\n line endings.
