### PR TITLE
use textContent to get the contents of the code element

### DIFF
--- a/angular-highlightjs.js
+++ b/angular-highlightjs.js
@@ -115,7 +115,7 @@ function HljsCtrl (hljsCache,   hljsService) {
     compile: function(tElm, tAttrs, transclude) {
       // get static code
       // strip the starting "new line" character
-      var staticCode = tElm[0].innerHTML.replace(/^(\r\n|\r|\n)/m, '');
+      var staticCode = tElm[0].textContent.replace(/^(\r\n|\r|\n)/m, '');
 
       // put template
       tElm.html('<pre><code class="hljs"></code></pre>');


### PR DESCRIPTION
this supports the use of character entities such as &lt; and &gt;

it's also the same technique used by highlight.js in the highlightBlock function https://github.com/isagalaev/highlight.js/blob/08062ea1c32f5a06b2b877ae2b4812d12f9355f1/src/highlight.js#L508
