### PR TITLE
Update README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ angular.module('myApp', ['hljs']);
 ## Install with npm
 
 ```sh
-npm install highlight.js
+npm install highlightjs
 npm install angular-highlightjs
 ```
 


### PR DESCRIPTION
Previously, the documentation suggested running `npm install highlight.js`
when the actual npm dependency is highlightjs.
